### PR TITLE
Change to material icon

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -143,7 +143,7 @@
             },
             "singleton": false,
             "ignoreConfigUpdate": true,
-            "fa-icon": "fa-commenting-o"
+            "fa-icon": "chat"
         }
     },
     "native": {


### PR DESCRIPTION
Remnants of the FontAwesome have been eliminated. Added materialize icons for tab.