### PR TITLE
Fix code for .ts,lc.ack and fix multiple objects in simpleControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ E.g.:
 
 You can read more about bindings here: (Bindings of objects)[https://github.com/ioBroker/ioBroker.vis#bindings-of-objects]
 
+Additional you can get time until now by {hm-rpc.0.light.STATE.lc;dateinterval} (2 minutes an 12 seconds) or {hm-rpc.0.light.STATE.lc;dateinterval(true)} (2 minutes and 12 seconds **ago**) 
+
 ## External rules with javascript
 There is a possibility to use javascript engine to process commands in text2command.
 To do that you must specify some state in "Processor state ID" (Advanced settings) and to listen on this state in some JS or Blockly script.

--- a/lib/formatProvider.js
+++ b/lib/formatProvider.js
@@ -1,0 +1,180 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+'use strict';
+
+var language        = "en"; // default language, if parameter is missed on function calls
+
+/**
+ * returns a text like 1 second or 5 minutes
+ * @param {integer} value the value
+ * @param {string} type 'seconds', 'minutes', 'hour' or 'days'
+ * @param {string} lang optional language, like de,ru or en. default is global languge, set by setLanguage
+ */
+function formatIntervalHelper (value, type, lang) {
+    var singular;
+    var plural;
+    var special24;
+    lang = lang || language;
+    if (lang === 'de') {
+        if (type === 'seconds') {
+            singular = 'Sekunde';
+            plural   = 'Sekunden';
+        } else if (type === 'minutes') {
+            singular = 'Minute';
+            plural   = 'Minuten';
+        } else if (type === 'hours') {
+            singular = 'Stunde';
+            plural   = 'Stunden';
+        } else if (type === 'days') {
+            singular = 'Tag';
+            plural   = 'Tagen';
+        }
+    } else if (lang === 'ru') {
+        if (type === 'seconds') {
+            singular  = 'секунду';
+            plural    = 'секунд';
+            special24 = 'секунды';
+        } else if (type === 'minutes') {
+            singular  = 'минуту';
+            plural    = 'минут';
+            special24 = 'минуты';
+        } else if (type === 'hours') {
+            singular  = 'час';
+            plural    = 'часов';
+            special24 = 'часа';
+        } else if (type === 'days') {
+            singular  = 'день';
+            plural    = 'дней';
+            special24 = 'дня';
+        }
+    } else {
+        if (type === 'seconds') {
+            singular = 'second';
+            plural   = 'seconds';
+        } else if (type === 'minutes') {
+            singular = 'minute';
+            plural   = 'minutes';
+        } else if (type === 'hours') {
+            singular = 'hour';
+            plural   = 'hours';
+        } else if (type === 'days') {
+            singular = 'day';
+            plural   = 'days';
+        }
+    }
+
+    if (value === 1) {
+        if (lang === 'de') {
+            if (type === 'days' ) {
+                return 'einem ' + singular;
+            } else {
+                return 'einer ' + singular;
+            }
+        } else if (lang === 'ru') {
+            if (type === 'days' || type === 'hours') {
+                return 'один ' + singular;
+            } else {
+                return 'одну ' + singular;
+            }
+        } else {
+            return 'one ' + singular;
+        }
+    } else {
+        if (lang === 'de') {
+            return value + ' ' + plural;
+        } else if (lang === 'ru') {
+            var d = value % 10;
+            if (d === 1 && value !== 11) {
+                return value + ' ' + singular;
+            } else
+            if (d >= 2 && d <= 4 && (value > 20 || value < 10)) {
+                return value + ' ' + special24;
+            } else {
+                return value + ' ' + plural;
+            }
+        } else {
+            return value + ' ' + plural;
+        }
+    }
+}
+
+/**
+ * formats a time difference to get something like 5 days and 4 hours ago 
+ * @param {long} timestamp time to differ with current time
+ * @param {boolean} useSuffix if true, the text will end with ago for en, otherwise only the time will retuned 
+ * @param {string} lang optional language, like de,ru or en. default is global languge, set by setLanguage
+ */
+function formatInterval (timestamp, useSuffix, lang) {
+    lang = lang || language;
+    var diff = new Date().getTime() - timestamp;
+    diff = Math.round(diff / 1000);
+    var text= '';
+    var connectorWord= ' and ';
+    if (lang === 'de') {
+        connectorWord= ' und ';
+    } else if (lang === 'ru') {
+        connectorWord= ' и ';
+    }
+
+    if (diff <= 60) {
+        text = formatIntervalHelper(diff, 'seconds',lang);
+    } else if (diff < 3600) {
+        var m = Math.floor(diff / 60);
+        var s = diff - m * 60;
+        text = formatIntervalHelper(m, 'minutes',lang);
+
+        if (m < 5 && s > 0) {
+            // add seconds
+            text += connectorWord + formatIntervalHelper(s, 'seconds',lang);
+        }
+    } else if (diff < 3600 * 24) {
+        var h = Math.floor(diff / 3600);
+        var m = Math.floor((diff - h * 3600) / 60);
+        text = formatIntervalHelper(h, 'hours',lang);
+
+        if (h < 10 && m > 0) {
+            // add minutes
+            text += connectorWord + formatIntervalHelper(m, 'minutes',lang);
+        }
+    } else {
+        var d = Math.floor(diff / (3600 * 24));
+        var h = Math.floor((diff - d * (3600 * 24)) / 3600);
+        text = formatIntervalHelper(d, 'days',lang);
+
+        if (d < 3 && h > 0) {
+            // add hours
+            text += connectorWord + formatIntervalHelper(h, 'hours',lang);
+        }
+    }
+    if (text && useSuffix){
+        if (lang === 'de') {
+            return 'vor ' + text;
+        } else if (lang === 'ru') {
+            return text + ' назад';
+        } else {
+            return text + ' ago';
+        }
+    } else
+        return text;
+}
+/**
+ * set defaultanguge for formatfunctions
+ * @param {*} lang 
+ */
+function setLanguage(lang){
+    language= lang;
+}
+
+module.exports = {
+    formatInterval : formatInterval,
+    formatIntervalHelper: formatIntervalHelper,
+    setLanguage: setLanguage
+}
+
+
+
+
+
+
+
+

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const simpleAnswers = require(__dirname + '/simpleAnswers');
+const formatProvider= require(__dirname + '/formatProvider'); // todo use formatProvider from js-controller/lib, if implemented
 const yes = [
     'true',
     'active',
@@ -214,7 +215,7 @@ function sayTemperature(lang, text, args, ack, cb) {
                 u = '';
             }
 
-            parseTemplates(ack, (err, ack) => {
+            parseTemplates(lang, ack, (err, ack) => {
                 if (lang === 'ru') {
                     // get last digit
                     let tr = t % 10;
@@ -343,7 +344,7 @@ function userDeviceControl(lang, text, args, ack, cb) {
                     //noinspection JSUnresolvedFunction
                     simpleAnswers.sayError(lang, err, args, ack, cb);
                 } else if (ack) {
-                    parseTemplates(ack, (err, ack) => {
+                    parseTemplates(lang, ack, (err, ack) => {
                         //noinspection JSUnresolvedFunction, JSUnresolvedVariable
                         cb(simpleAnswers.getRandomPhrase(ack).replace('%s', args[1]).replace('%u', units).replace('%n', getObjectName(lang, obj)));
                     });
@@ -417,7 +418,7 @@ function userQuery(lang, text, args, ack, cb) {
                         }
                     }
 
-                    parseTemplates(ack, (err, ack) => {
+                    parseTemplates(lang, ack, (err, ack) => {
                         //noinspection JSUnresolvedVariable,JSUnresolvedFunction
                         cb(simpleAnswers.getRandomPhrase(ack).replace('%s', state.val.toString()).replace('%u', units).replace('%n', getObjectName(lang, obj)));
                     });
@@ -431,7 +432,7 @@ function userQuery(lang, text, args, ack, cb) {
 }
 
 function buildAnswer(lang, text, args, ack, cb) {
-    parseTemplates(ack, (err, ack) => {
+    parseTemplates(lang, ack, (err, ack) => {
         //noinspection JSUnresolvedVariable,JSUnresolvedFunction
         cb(simpleAnswers.getRandomPhrase(ack));
     });
@@ -596,7 +597,7 @@ function extractBinding(format) {
                             }
                         } else
                         // date formatting
-                        if (parse[1] === 'date') {
+                        if (parse[1] === 'date' || parse[1] === 'dateinterval') {
                             operations = operations || [];
                             parse[2] = (parse[2] || '').trim();
                             parse[2] = parse[2].substring(1, parse[2].length - 1);
@@ -664,7 +665,7 @@ function extractBinding(format) {
     return result;
 }
 
-function parseTemplates(format, cb){
+function parseTemplates(lang, format, cb){
     let oids= extractBinding(format);
     
     if (!oids) {
@@ -681,17 +682,17 @@ function parseTemplates(format, cb){
                 }
                 _values.length--;
                 if (_values.length == 0)
-                    setImmediate(executeTemplates, format, cb, _values, oids);
+                    setImmediate(executeTemplates, lang, format, cb, _values, oids);
             });
         } else{
             _values.length--;
             if (_values.length == 0)
-                executeTemplates(format, cb, _values, oids);
+                executeTemplates(lang, format, cb, _values, oids);
         }
     }
 }
 
-function executeTemplates(format, cb, _values, oids) {
+function executeTemplates(lang, format, cb, _values, oids) {
     for (let t = 0; t < oids.length; t++) {
         let value = _values[oids[t].visOid];
         if (oids[t].operations) {
@@ -781,6 +782,9 @@ function executeTemplates(format, cb, _values, oids) {
                     case 'date':
                         value = adapter.formatDate(value, oids[t].operations[k].arg);
                         break;
+                    case 'dateinterval':
+                        value = formatProvider.formatInterval(value, oids[t].operations[k].arg,lang);
+                        break;                        
                     case 'min':
                         value = parseFloat(value);
                         value = (value < oids[t].operations[k].arg) ? oids[t].operations[k].arg : value;
@@ -819,7 +823,7 @@ function sendText(lang, text, args, ack, cb) {
 
     if (args[1]) text = args[1].replace('%s', text);
 
-    parseTemplates(text, (err, text) => {
+    parseTemplates(lang, text, (err, text) => {
         adapter.log.info('Say ID ' + args[0] + ': ' + text);
 
         //noinspection JSUnresolvedFunction

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -496,7 +496,7 @@ function extractBinding(format) {
             }
 
             let isSeconds = (test2 === '.ts' || test2 === '.lc');
-            let attr= "val";
+            let attr = 'val';
 
             test1 = systemOid.substring(systemOid.length - 4);
             test2 = systemOid.substring(systemOid.length - 3);

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -495,14 +495,17 @@ function extractBinding(format) {
             }
 
             let isSeconds = (test2 === '.ts' || test2 === '.lc');
+            let attr= "val";
 
             test1 = systemOid.substring(systemOid.length - 4);
             test2 = systemOid.substring(systemOid.length - 3);
 
             if (test1 === '.val' || test1 === '.ack') {
                 systemOid = systemOid.substring(0, systemOid.length - 4);
+                attr= test1.slice(1);
             } else if (test2 === '.lc' || test2 === '.ts') {
                 systemOid = systemOid.substring(0, systemOid.length - 3);
+                attr= test2.slice(1);
             }
             let operations = null;
             let isEval = visOid.match(/[\d\w_.]+:\s?[-\d\w_.]+/) || (!visOid.length && parts.length > 0);//(visOid.indexOf(':') !== -1) && (visOid.indexOf('::') === -1);
@@ -653,34 +656,43 @@ function extractBinding(format) {
                 token: oid[p],
                 operations: operations ? operations : undefined,
                 format: format,
-                isSeconds: isSeconds
+                isSeconds: isSeconds,
+                attr: attr
             });
         }
     }
     return result;
 }
 
-function parseTemplates(format, cb, _values, oids) {
-    oids = oids || extractBinding(format);
-    _values = _values || {};
-
+function parseTemplates(format, cb){
+    let oids= extractBinding(format);
+    
     if (!oids) {
         return cb(null, format);
     }
+    let _values = {length:oids.length};
 
     for (let t = 0; t < oids.length; t++) {
-        let value;
-        if (oids[t].systemOid && _values[oids[t].systemOid] === undefined) {
+        if (oids[t].visOid && _values[oids[t].visOid] === undefined) {
             adapter.getForeignState(oids[t].systemOid, (err, state) => {
-                _values[oids[t].systemOid] = state ? state.val : '';
-                if (_values[oids[t].systemOid] === undefined || _values[oids[t].systemOid] === null) {
-                    _values[oids[t].systemOid] = ''
+                _values[oids[t].visOid] = state ? state[oids[t].attr || 'val'] : '';
+                if (_values[oids[t].visOid] === undefined || _values[oids[t].visOid] === null) {
+                    _values[oids[t].visOid] = ''
                 }
-                setImmediate(parseTemplates, format, cb, _values, oids);
+                _values.length--;
+                if (_values.length <= 0)
+                    setImmediate(executeTemplates, format, cb, _values, oids);
             });
-            return;
-        }
-        value = _values[oids[t].systemOid];
+        } else
+            _values.length--;
+    }
+    if (_values.length <= 0)
+        executeTemplates(format, cb, _values, oids);
+}
+
+function executeTemplates(format, cb, _values, oids) {
+    for (let t = 0; t < oids.length; t++) {
+        let value = _values[oids[t].visOid];
         if (oids[t].operations) {
             for (let k = 0; k < oids[t].operations.length; k++) {
                 switch (oids[t].operations[k].op) {
@@ -688,7 +700,7 @@ function parseTemplates(format, cb, _values, oids) {
                         let string = '';//'(function() {';
                         for (let a = 0; a < oids[t].operations[k].arg.length; a++) {
                             if (!oids[t].operations[k].arg[a].name) continue;
-                            value = _values[oids[t].operations[k].arg[a].systemOid];
+                            value = _values[oids[t].operations[k].arg[a].visOid];
                             string += 'var ' + oids[t].operations[k].arg[a].name + ' = "' + value + '";';
                         }
                         let formula = oids[t].operations[k].formula;
@@ -760,13 +772,13 @@ function parseTemplates(format, cb, _values, oids) {
                         if (value.length < 2) value = '0' + value;
                         break;
                     case 'value':
-                        value = this.formatValue(value, parseInt(oids[t].operations[k].arg, 10));
+                        value = adapter.formatValue(value, parseInt(oids[t].operations[k].arg, 10));
                         break;
                     case 'array':
                         value = oids[t].operations[k].arg [~~value];
                         break;
                     case 'date':
-                        value = this.formatDate(value, oids[t].operations[k].arg);
+                        value = adapter.formatDate(value, oids[t].operations[k].arg);
                         break;
                     case 'min':
                         value = parseFloat(value);

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -680,14 +680,15 @@ function parseTemplates(format, cb){
                     _values[oids[t].visOid] = ''
                 }
                 _values.length--;
-                if (_values.length <= 0)
+                if (_values.length == 0)
                     setImmediate(executeTemplates, format, cb, _values, oids);
             });
-        } else
+        } else{
             _values.length--;
+            if (_values.length == 0)
+                executeTemplates(format, cb, _values, oids);
+        }
     }
-    if (_values.length <= 0)
-        executeTemplates(format, cb, _values, oids);
 }
 
 function executeTemplates(format, cb, _values, oids) {

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -503,10 +503,10 @@ function extractBinding(format) {
 
             if (test1 === '.val' || test1 === '.ack') {
                 systemOid = systemOid.substring(0, systemOid.length - 4);
-                attr= test1.slice(1);
+                attr = test1.slice(1);
             } else if (test2 === '.lc' || test2 === '.ts') {
                 systemOid = systemOid.substring(0, systemOid.length - 3);
-                attr= test2.slice(1);
+                attr = test2.slice(1);
             }
             let operations = null;
             let isEval = visOid.match(/[\d\w_.]+:\s?[-\d\w_.]+/) || (!visOid.length && parts.length > 0);//(visOid.indexOf(':') !== -1) && (visOid.indexOf('::') === -1);

--- a/lib/simpleControl.js
+++ b/lib/simpleControl.js
@@ -666,12 +666,12 @@ function extractBinding(format) {
 }
 
 function parseTemplates(lang, format, cb){
-    let oids= extractBinding(format);
+    let oids = extractBinding(format);
     
     if (!oids) {
         return cb(null, format);
     }
-    let _values = {length:oids.length};
+    let _values = {length: oids.length};
 
     for (let t = 0; t < oids.length; t++) {
         if (oids[t].visOid && _values[oids[t].visOid] === undefined) {
@@ -684,10 +684,11 @@ function parseTemplates(lang, format, cb){
                 if (_values.length == 0)
                     setImmediate(executeTemplates, lang, format, cb, _values, oids);
             });
-        } else{
+        } else {
             _values.length--;
-            if (_values.length == 0)
+            if (_values.length == 0) {
                 executeTemplates(lang, format, cb, _values, oids);
+            }
         }
     }
 }

--- a/main.js
+++ b/main.js
@@ -293,6 +293,3 @@ function main() {
         devicesControl.init(enums, adapter);
     });
 }
-
-
-

--- a/main.js
+++ b/main.js
@@ -293,3 +293,6 @@ function main() {
         devicesControl.init(enums, adapter);
     });
 }
+
+
+

--- a/test/testFormatProvider.js
+++ b/test/testFormatProvider.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var expect = require('chai').expect;
+//var setup  = require(__dirname + '/lib/setup');
+var formatProvider = require(__dirname + '/../lib/formatProvider');
+var debug = true;
+
+describe('Commands: Test dateInterval without suffix in default language', function () {
+    it('must return 2 minutes and 20 seconds', function (done) {
+        let out= formatProvider.formatInterval(new Date().getTime() - 2 * 60 * 1000 - 20 * 1000 );
+        if (debug) console.log('formatInterval returned: ' + out);
+        expect(out).is.equal('2 minutes and 20 seconds');
+        done();
+    });
+
+    it('must return 7 Minuten', function (done) {
+        formatProvider.setLanguage("de");
+        let out= formatProvider.formatInterval(new Date().getTime() - 7 * 60 * 1000 - 20 * 1000 );
+        if (debug) console.log('formatInterval returned: ' + out);
+        expect(out).is.equal('7 Minuten');
+        done();
+    });
+});
+
+describe('Commands: Test dateInterval with suffix in german language', function () {
+    it('must return vor 3 Stunden und 2 Minuten', function (done) {
+        let out= formatProvider.formatInterval(new Date().getTime() - 3 * 60 * 60 * 1000 - 2 * 60 * 1000 - 20 * 1000, true, "de" );
+        if (debug) console.log('formatInterval returned: ' + out);
+        expect(out).is.equal('vor 3 Stunden und 2 Minuten');
+        done();
+    });
+
+    it('must return vor 5 Tagen', function (done) {
+        let out= formatProvider.formatInterval(new Date().getTime() - 5 * 24 * 60 * 60 * 1000 - 7 * 60 * 1000 - 20 * 1000, true, "de" );
+        if (debug) console.log('formatInterval returned: ' + out);
+        expect(out).is.equal('vor 5 Tagen');
+        done();
+    });
+
+    it('must return vor einem Tag', function (done) {
+        let out= formatProvider.formatInterval(new Date().getTime() - 1 * 24 * 60 * 60 * 1000 - 7 * 60 * 1000 - 20 * 1000, true, "de" );
+        if (debug) console.log('formatInterval returned: ' + out);
+        expect(out).is.equal('vor einem Tag');
+        done();
+    });    
+});


### PR DESCRIPTION
Ich schreib mal auf deutsch...

Diese Pullrequest basiert auf meinem erstellten Issue https://github.com/ioBroker/ioBroker.text2command/issues/33

Mir ist aufgefallen, dann man bei Antwort erzeugen ( und ich denke genrell beim Quittungstext) zum einen immer nur der value eines Objectes ausgegeben werden kann. Des weiteren habe ich auch immer nur ein Object aufgelöst bekommen, wenn ich folgenden Quittungstext eingegeben habe:
Der Trockner ist aktuell {#Keller.0.Trockner.State;array(aus,an,läuft)} seit {#Keller.0.Trockner.State.ts;date(hh:mm)}

Ich habe mir daraufhin den code mal angeschaut und habe mal einen patch Vorschlag. Bei mir funktioniert es damit.
simpleControl.patch.txt

Ich denke Issue #22 würde damit auch funktionieren

Gruss
Dirk

