### PR TITLE
bugfix in devicesControl.js

### DIFF
--- a/lib/devicesControl.js
+++ b/lib/devicesControl.js
@@ -354,7 +354,7 @@ function generateAnswerOnOff(lang, sRoom, sFunction, valPercent) {
         }
     } else
     if (lang === 'de') {
-        toSay = (valPercent === true || valPercent === false) ? 'Schalte ' : 'Setzte ';
+        toSay = (valPercent === true || valPercent === false) ? 'Schalte ' : 'Setze ';
         //noinspection JSUnresolvedVariable
         toSay += functions.functionsAccusative[sFunction][lang] + ' ';
         //noinspection JSUnresolvedVariable

--- a/lib/devicesControl.js
+++ b/lib/devicesControl.js
@@ -550,7 +550,7 @@ function controlByFunction(lang, text, args, ack, cb) {
 }
 
 function controlBlinds(lang, text, args, ack, cb) {
-    return controlByFunctionHelper(lang, text, args, ack, cb, 'blind', extractBlindCmd, generateAnswerBlinds);
+    return controlByFunctionHelper(lang, text, args, ack, cb, 'blinds', extractBlindCmd, generateAnswerBlinds);
 }
 
 function init(_enums, _adapter) {

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -8,7 +8,7 @@ const functions = {
     "backlight/beleuchtung/подсветка":    {"ru" : "подсветк/светильник","de": "beleuchtung/rücklicht", "en": "back light/back light/rear light" },
     "light/licht/свет":                   {"ru" : "свет/лампу/лампа",   "de": "licht/lampe",     "en": "light/lamp" },
     "heating/heizung/отопление":          {"ru" : "отопление/батаре",   "de": "heizung",         "en": "heating" },
-    "blind/rollade/rolladen/жалюзи/окна": {"ru" : "жалюзи/ставни",      "de": "rollade",         "en": "shutter" },
+    "blind/rollladen/rolladen/жалюзи/окна": {"ru" : "жалюзи/ставни",    "de": "rollladen",       "en": "shutter" },
     "music/musik/музыка":                 {"ru" : "музык",              "de": "musik",           "en": "music" },
     "security/sicherheit/alarm/alarmanlage/сигнализация/охрана": {"ru" : "сигнал/охран", "de": "sicherheit/alarm", "en": "security/alarm" },
     "lock/door/schloß/tür/замок/дверь":   {"ru" : "замок/дверь/ворота", "de": "verschluß/schloß/tür","en": "lock/door" }
@@ -19,7 +19,7 @@ const functionsGenitive = {
     "backlight/beleuchtung/подсветка":    {"ru" : "подсветки",          "de": "e Beleuchtung",  "en": "back light" },
     "light/licht/свет":                   {"ru" : "ламп",               "de": "e Lampen",       "en": "light" },
     "heating/heizung/отопление":          {"ru" : "отопление",          "de": "e Heizung",      "en": "heating" },
-    "blind/rollade/rolladen/жалюзи/окна": {"ru" : "жалюзей",            "de": "e Rolladen",     "en": "shutter" },
+    "blind/rollladen/rolladen/жалюзи/окна": {"ru" : "жалюзей",          "de": "e Rollladen",    "en": "shutter" },
     "music/musik/музыка":                 {"ru" : "музыки",             "de": "e Musik",        "en": "music" },
     "security/sicherheit/alarm/alarmanlage/сигнализация/охрана": {"ru" : "сигнализации", "de": "e Sicherheitssystem", "en": "security" },
     "lock/door/schloß/tür/замок/дверь":   {"ru" : "замков",             "de": "e Verschluße",   "en": "lock" }
@@ -30,7 +30,7 @@ const functionsAccusative = {
     "backlight/beleuchtung/подсветка":    {"ru" : "подсветку",          "de": "die Beleuchtung","en": "back light" },
     "light/licht/свет":                   {"ru" : "свет",               "de": "das Licht",      "en": "light" },
     "heating/heizung/отопление":          {"ru" : "отопление",          "de": "die Heizung",    "en": "heating" },
-    "blind/rollade/rolladen/жалюзи/окна": {"ru" : "жалюзи",             "de": "die Rolladen",   "en": "shutter" },
+    "blind/rollladen/rolladen/жалюзи/окна": {"ru" : "жалюзи",           "de": "die Rollladen",  "en": "shutter" },
     "music/musik/музыка":                 {"ru" : "музыку",             "de": "die Musik",      "en": "music" },
     "security/sicherheit/alarm/alarmanlage/сигнализация/охрана": {"ru" : "сигнализацию", "de": "das Sicherheitssystem", "en": "security" },
     "lock/door/schloß/tür/замок/дверь":   {"ru" : "замок",              "de": "den Verschluß",  "en": "lock" }


### PR DESCRIPTION
changed "blind" to "blinds" accourding to the standard name of enum.functions.blinds
Otherwise the rollershutter function won't work without building an new enum enum.funtions.blind (without s)