### PR TITLE
changes due to git conventions, typo and command additions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018, Bluefox (dogafox@gmail.com)
+Copyright (c) 2016-2019, Bluefox (dogafox@gmail.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ First the command will be processed with your javascript and if javascript will 
 
 ## Changelog
 
+### 1.3.1 (2019-07-18)
+
+* (unltdnetworx) changed copyright year to 2019, according to issue #41
+* (unltdnetworx) additional words for blinds and functions in english and german
+* (unltdnetworx) fixed typo
+
 ### 1.3.0 (2019-07-18)
 
 * (bluefox) Using the defined language by words

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Logo](admin/text2command.png)
+
 # text2command
+
 =================
 
 ![Number of Installations](http://iobroker.live/badges/text2command-installed.svg) ![Number of Installations](http://iobroker.live/badges/text2command-stable.svg) [![NPM version](http://img.shields.io/npm/v/iobroker.text2command.svg)](https://www.npmjs.com/package/iobroker.text2command)
@@ -9,11 +11,13 @@
 [![NPM](https://nodei.co/npm/iobroker.text2command.png?downloads=true)](https://nodei.co/npm/iobroker.text2command/)
 
 ## Description
+
 This adapter can convert normal sentences, like *'Switch light in kitchen on'* to specific command and sets the state *'adapter.0.device.kitchenLight'* to **true**.
 
 This adapter make no sense to be activated standalone. It should be used with other adapters like telegram or Android app **iobroker.vis**.
 
 ## Usage
+
 To execute command, write state **text2command.<INSTANCE>.text** with sentence. You will always get the answer in **text2command.<INSTANCE>.response**.
 
 If you define **Answer to ID**, the answer will be written in this ID too. This required for e.g. to realise the voice acknowledges.
@@ -31,6 +35,7 @@ Regular expressions can be used, like: ```/^light\son|^lamp\son/```. Regular exp
 To use "Switch on/off by function" you should care of functions.
 
 Keywords work as following:
+
 - keywords are divided by space
 - all keywords must present in a sentence to trigger a rule: e.g. keyword: ```light on``` will trigger on ```switch light on```, ```make light on everywhere``` and do not trigger on ```switch on```, ```make light```.
 - one keyword can has many forms. Variations of keyword must be divided by "/". E.g. keywords: ```switch/make/do light on/true``` will trigger on: ```do light true```, ```make please light on```.
@@ -41,33 +46,41 @@ Following functions will be interpreted as
 enum.functions:
 
 **enum.functions.light** (Licht | Свет):
+
 - roles - level.dimmer
 - roles - switch.light
 
 **enum.functions.backlight** (Beleuchtung | Подсветка):
+
 - roles - level.backlight
 - roles - switch.backlight
 
 **enum.functions.blinds/shutter** (Rolladen | Жалюзи/окна)
+
 - roles - level.blind
 - roles - switch.blind
 
 **enum.functions.curtain** (Vorhänge | Шторы)
+
 - roles - level.curtain
 - roles - switch.curtain
 
 **enum.functions.heating** (Heizung | Отопление/Подогрев)
+
 - roles - level.temperature
 - roles - switch.temperature
 
 **enum.functions.music** (Musik | Музыка)
+
 - roles - button.play
 - roles - button.stop / button.pause
 
 **enum.functions.alarm/security** (Alarmanlage / Alarm | Охрана)
+
 - roles - switch.security
 
 **enum.functions.lock** (Schloß / Schloss | Замок)
+
 - roles - switch.open
 - roles - switch.lock
 
@@ -101,6 +114,7 @@ Following rooms are supported:
 | summer house          | summerhouse                     | gartenhaus               | теплица                |
 
 You can use patterns in acknowledges:
+
 - %s : value
 - %u : unit
 - %n : name (planned!)
@@ -109,22 +123,27 @@ You can use patterns in acknowledges:
 Following commands are supported:
 
 ### What time is it?
+
 Answer: 14:56 (current time)
 
 ### What is your name?
+
 Answer is customizable. Default: ```My name is Alpha```
 
 ### What is the outside temperature?
+
 User must specify the state ID, where to read outside temperature.
 Answer is customizable. Default: ```Outside temperature is %s %u```
 **%s** will be replaced by temperature, rounded to integer. **%u** will be replaced by units of this state or by system temperature units.
 
 ### What is the inside temperature?
+
 User must specify the state ID, where to read inside temperature.
 Answer is customizable. Default: ```Inside temperature is %s %u```
 **%s** will be replaced by temperature, rounded to integer. **%u** will be replaced by units of this state or by system temperature units.
 
 ### Switch on/off by function
+
 This command reads information from enums. It uses **enum.functions** to find type of device (e.g light, alarm, music) and **enum.rooms** to detect room name.
 
 Example in german:
@@ -141,6 +160,7 @@ Command accept the numeric value too. It has priority, e.g. in command ```switch
 You can define default room in []. E.g ```switch the light on[sleepingroom]```
 
 ### Open/close blinds
+
 This command reads information from enums. It uses **enum.functions.blind** to find type blinds or shutter and **enum.rooms** to detect room name.
 
 Key words to move blinds up are: *blinds up*, e.g. ```set blinds up in sleeping room```
@@ -152,6 +172,7 @@ You can specify the exactly position of blind in percent, e.g. ```move blinds to
 Answer will be generated automatically if desired: ``` in %room%```, where %room% will be replaced by found device type and location.
 
 ### Switch something on/off
+
 User must specify state ID of device, which must be controlled and value, which must be written.
 
 You should create rule for every position (e.g. for *on* and for *off*).
@@ -176,6 +197,7 @@ If command is like ```Set light level to 50%```, so into the ```hm-rpc.0.light.S
 If command is like ```Set light level```, so into the ```hm-rpc.0.light.STATE``` will be written 10 and answer will be ```Level set to 10%```.
 
 ### Ask about something
+
 User must specify state ID of device, which value will be read.
 This template will answer with information from some state.
 
@@ -185,20 +207,24 @@ E.g.:
 - ```temperature sleeping room```, Object ID: ```hm-rpc.0.sleepingRoomSensor.TEMPERATURE```, Acknowledge: ```Actual temperature in sleeping room is %s %u/%s %u```. In this case the answer will be randomized between *Actual temperature in sleeping room is %s %u* and *%s %u*.
 
 ### Send text to state
+
 You can write some text into state. User must specify state ID to write text into it.
 
 E.g. rule: ```email [to] wife```, Object ID: ```javascript.0.emailToWife```, Acknowledge: ```Email sent```
 Text: *Send email to my wife: I will be late*. Adapter looks for the last word from key words (in this case *wife*),
 extracts text from the next word (in this case *I will be late*) and writes this text into *javascript.0.emailToWife*.
-Word *to* is not required to trigger the rule, but will be removed from text.   
+Word *to* is not required to trigger the rule, but will be removed from text.
 
 ### You are good (Just for fun)
+
 Answer is customizable. Default: ```Thank you``` or ```You are welcome```
 
 ### Thank you (Just for fun)
+
 Answer is customizable. Default: ```No problem``` or ```You are welcome```
 
 ### Create answer
+
 You can generate answer with bindings {objectId} in acknowledge. Used for alexa.
 
 E.g.:
@@ -211,6 +237,7 @@ You can read more about bindings here: (Bindings of objects)[https://github.com/
 Additional you can get time until now by {hm-rpc.0.light.STATE.lc;dateinterval} (2 minutes an 12 seconds) or {hm-rpc.0.light.STATE.lc;dateinterval(true)} (2 minutes and 12 seconds **ago**) 
 
 ## External rules with javascript
+
 There is a possibility to use javascript engine to process commands in text2command.
 To do that you must specify some state in "Processor state ID" (Advanced settings) and to listen on this state in some JS or Blockly script.
 You can create some state manually in admin or in script. Processing script can looks like this one:
@@ -242,101 +269,133 @@ Set in settings of text2command **Processor state ID** as *javascript.0.textProc
 First the command will be processed with your javascript and if javascript will answer with '' or not answer in predefined time (1 second by default) the command will be processed by rules.
 
 # ToDo
+
 - in Russian male and female answers.
 
 ## Changelog
+
 ### 1.3.0 (2019-07-18)
+
 * (bluefox) Using the defined language by words
 
 ### 1.2.5 (2019-02-12)
+
 * (unltdnetworx) description in german corrected
 * (unltdnetworx) added percent to true/false rules
 
 ### 1.2.4 (2018-05-05)
+
 * (Apollon77) Fix
 
 ### 1.2.3 (2018-05-01)
+
 * (bluefox) Support of bindings in answer {objId}
 
 ### 1.2.0 (2018-04-23)
+
 * (bluefox) Support of Admin3 (but not materialize style)
 
 ### 1.1.7 (2018-04-04)
+
 * (bluefox) The parsing error was fixed
 
 ### 1.1.6 (2017-10-05)
+
 * (bluefox) Check if units are undefined
 
 ### 1.1.5 (2017-08-14)
+
 * (bluefox) Support of iobroker.pro
 
 ### 1.1.4 (2017-03-27)
+
 * (bluefox) translations
 
 ### 1.1.3 (2016-08-30)
+
 * (bluefox) russian translations
 
 ### 1.1.2 (2016-08-29)
+
 * (bluefox) fix the russian temperature text
 * (bluefox) extend rule "control device" with option 0/1
 * (bluefox) use by control of devices min/max values if set
 
 ### 1.1.1 (2016-08-19)
+
 * (bluefox) add additional info for external text processor
 
 ### 1.1.0 (2016-08-16)
+
 * (bluefox) add text processor state ID
 
 ### 1.0.2 (2016-07-22)
+
 * (bluefox) fix error with detection of numeric values
 
 ### 1.0.1 (2016-06-01)
+
 * (bluefox) fix: send text command
 
 ### 1.0.0 (2016-05-05)
+
 * (bluefox) replace special chars in input text: #'"$&/\!?.,;:(){}^
 
 ### 0.1.10 (2016-03-20)
+
 * (bluefox) fix double pronunciation of some answers
 
 ### 0.1.9 (2016-03-20)
+
 * (bluefox) ignore spaces
 
 ### 0.1.8 (2016-03-15)
+
 * (bluefox) fix error with enums
 
 ### 0.1.7 (2016-03-12)
+
 * (bluefox) implement "say something"
 
 ### 0.1.6 (2016-02-24)
+
 * (bluefox) fix temperature
 
 ### 0.1.5 (2016-02-23)
+
 * (bluefox) fix russian outputs
 
 ### 0.1.4 (2016-02-22)
+
 * (bluefox) fix russian outputs
 
 ### 0.1.3 (2016-02-21)
+
 * (bluefox) round temperature in answers
 
 ### 0.1.2 (2016-02-21)
+
 * (bluefox) implement russian time
 
 ### 0.1.1 (2016-02-19)
+
 * (bluefox) check invalid commands
 
 ### 0.1.0 (2016-02-19)
+
 * (bluefox) fix problem with controlling of channels
 * (bluefox) enable write JSON as argument
 
 ### 0.0.3 (2016-02-14)
+
 * (bluefox) remove unused files
 
 ### 0.0.2 (2016-02-10)
+
 * (bluefox) extend readme
 
 ### 0.0.1 (2016-02-09)
+
 * (bluefox) initial commit
 
 ## Install
@@ -347,7 +406,7 @@ First the command will be processed with your javascript and if javascript will 
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2018, bluefox<dogafox@gmail.com>
+Copyright (c) 2014-2019, bluefox <dogafox@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/admin/langModel.js
+++ b/admin/langModel.js
@@ -125,14 +125,14 @@ var commands = {
     'functionOnOff': {
         icon: '',
         name: {
-            'en': "Switch on/off by function",
+            'en': "switch on/off by function",
             'de': "Schalte an oder aus mit Funktion",
             'ru': "Включить/выключить приборы"
         },
         unique:   true,
         editable: false,
         words: {
-            'en': "switch on/off/percent",
+            'en': "switch/turn/set on/off/percent",
             'de': "einschalten/ausschalten/ein/aus/an/prozent",
             'ru': "ключи/включи/включить/выключи/выключить/потушить/потуши/зажги/зажечь/процентов/процент/процента"
         },
@@ -157,15 +157,15 @@ var commands = {
     'blindsUpDown': {
         icon: '',
         name: {
-            'en': "Open/close blinds",
+            'en': "open/close blinds",
             'de': "Rollladen auf/zu machen",
             'ru': "Поднять/опустить ставни"
         },
         unique:   true,
         editable: false,
         words: {
-            'en': "blinds/shutter up/down/percent",
-            'de': "rollladen/rolladen/beschattung/fenster/laden/rollo auf/zu/hoch/runter/prozent",
+            'en': "blind/blinds/shutter/shutters up/down/percent",
+            'de': "rollladen/rollläden/rolladen/rolläden/beschattung/fenster/laden/rollo auf/zu/hoch/runter/prozent",
             'ru': "ставни/окно/окна/жалюзи поднять/подними/опустить/опусти/открой/открою/открыть/закрыть/закрою/закрой/процентов/процент/процента"
         },
         ack: {

--- a/admin/tab.js
+++ b/admin/tab.js
@@ -443,7 +443,7 @@ function Text2Commands(main, instance) {
                         var oldId = $('#dialog-replace-old-id').val();
                         var newId = $('#dialog-replace-new-id').val();
                         if (oldId === newId) {
-                            console.warn('IDs re equal');
+                            console.warn('IDs are equal');
                             return;
                         }
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,20 @@
 {
     "common": {
         "name": "text2command",
-        "version": "1.3.0",
+        "version": "1.3.1",
         "news": {
+            "1.3.1": {
+                "en": "changes due to git conventions, command additions and typo",
+                "de": "Änderungen aufgrund von Git-Konventionen, Befehlsergänzungen und Tippfehler",
+                "ru": "изменения из-за соглашений git, дополнений команд и опечаток",
+                "pt": "mudanças devido a convenções de git, adições de comando e erro de digitação",
+                "nl": "veranderingen als gevolg van git conventies, opdracht toevoegingen en typfouten",
+                "fr": "modifications dues aux conventions git, aux ajouts de commandes et aux fautes de frappe",
+                "it": "modifiche dovute a convenzioni git, aggiunte di comandi e errori di battitura",
+                "es": "Cambios debidos a convenciones de git, adiciones de comandos y errores tipográficos.",
+                "pl": "zmiany spowodowane konwencjami git, dodatkami do poleceń i literówką",
+                "zh-cn": "由git约定，命令添加和拼写错误引起的更改"
+            },
             "1.3.0": {
                 "en": "Using the defined language by words",
                 "de": "Die definierte Sprache in Worten verwenden",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.text2command",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convert texts to ioBroker commands.",
   "author": {
     "name": "bluefox",


### PR DESCRIPTION
This pull request corrects a typo and adds empty lines before and after headings in the readme, due to conventions of github.

Also there are new words for commands.