### PR TITLE
Fix for RegExp usage in rules

### DIFF
--- a/admin/langModel.js
+++ b/admin/langModel.js
@@ -732,7 +732,7 @@ function findMatched(cmd, _rules) {
         if (typeof rule.words === 'string') {
             // if regex
             if (rule.words[0] === '/') {
-                rule.words = new RegExp(rule.words, 'i');
+                rule.words = new RegExp(rule.words.slice(1,-1), 'i');
             } else {
                 rule.words = rule.words.toLowerCase().trim().split(/\s+/g);
             }

--- a/lib/langModel.js
+++ b/lib/langModel.js
@@ -732,7 +732,7 @@ function findMatched(cmd, _rules) {
         if (typeof rule.words === 'string') {
             // if regex
             if (rule.words[0] === '/') {
-                rule.words = new RegExp(rule.words, 'i');
+                rule.words = new RegExp(rule.words.slice(1,-1), 'i');
             } else {
                 rule.words = rule.words.toLowerCase().trim().split(/\s+/g);
             }

--- a/src/public/langModel.js
+++ b/src/public/langModel.js
@@ -732,7 +732,7 @@ function findMatched(cmd, _rules) {
         if (typeof rule.words === 'string') {
             // if regex
             if (rule.words[0] === '/') {
-                rule.words = new RegExp(rule.words, 'i');
+                rule.words = new RegExp(rule.words.slice(1,-1), 'i');
             } else {
                 rule.words = rule.words.toLowerCase().trim().split(/\s+/g);
             }


### PR DESCRIPTION
For right converting from String to RegExp the `slash brackets` have to be excluded from source string for right conversion.
I.e.
```
new RegExp('/.*/','i')
```
will create an empty RegExp, in comparison with
```
new RegExp('.*','i')
```
